### PR TITLE
Implement Disqus reaction preview

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,9 @@
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+    if (msg.type === 'fetchReactions') {
+        fetch(msg.url)
+            .then(res => res.text())
+            .then(html => sendResponse({html}))
+            .catch(() => sendResponse({html: null}));
+        return true;
+    }
+});

--- a/background.js
+++ b/background.js
@@ -1,6 +1,11 @@
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     if (msg.type === 'fetchReactions') {
-        fetch(msg.url)
+        fetch(msg.url, {
+            headers: {
+                'Referer': msg.articleUrl
+            },
+            credentials: 'omit'
+        })
             .then(res => res.text())
             .then(html => sendResponse({html}))
             .catch(() => sendResponse({html: null}));

--- a/content.js
+++ b/content.js
@@ -44,3 +44,35 @@ function toggleArticlesByLinks(hide, wildcard) {
         }
     });
 }
+
+async function fetchReactions(url) {
+    try {
+        const res = await fetch(url);
+        const text = await res.text();
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(text, 'text/html');
+        return doc.querySelector('#reactions');
+    } catch (e) {
+        console.error('Failed to fetch reactions', e);
+        return null;
+    }
+}
+
+function insertReactions(article, reactions) {
+    if (!reactions) return;
+    const clone = reactions.cloneNode(true);
+    clone.style.marginTop = '10px';
+    const target = article.querySelector('.article_date') || article;
+    target.parentNode.insertBefore(clone, target.nextSibling);
+}
+
+function loadReactionsForArticles() {
+    document.querySelectorAll('.article').forEach(article => {
+        const link = article.querySelector('.article_title a');
+        if (link) {
+            fetchReactions(link.href).then(reactions => insertReactions(article, reactions));
+        }
+    });
+}
+
+loadReactionsForArticles();

--- a/content.js
+++ b/content.js
@@ -45,7 +45,7 @@ function toggleArticlesByLinks(hide, wildcard) {
     });
 }
 
-async function fetchReactions(articleUrl, identifier) {
+function fetchReactions(articleUrl, identifier) {
     const params = new URLSearchParams({
         base: 'default',
         f: 'mezha-media',
@@ -54,16 +54,17 @@ async function fetchReactions(articleUrl, identifier) {
         's_o': 'popular'
     });
     const embedUrl = `https://disqus.com/embed/comments/?${params.toString()}`;
-    try {
-        const res = await fetch(embedUrl);
-        const text = await res.text();
-        const parser = new DOMParser();
-        const doc = parser.parseFromString(text, 'text/html');
-        return doc.querySelector('#reactions');
-    } catch (e) {
-        console.error('Failed to fetch reactions', e);
-        return null;
-    }
+    return new Promise(resolve => {
+        chrome.runtime.sendMessage({type: 'fetchReactions', url: embedUrl}, ({html}) => {
+            if (html) {
+                const parser = new DOMParser();
+                const doc = parser.parseFromString(html, 'text/html');
+                resolve(doc.querySelector('#reactions'));
+            } else {
+                resolve(null);
+            }
+        });
+    });
 }
 
 function insertReactions(article, reactions) {

--- a/content.js
+++ b/content.js
@@ -45,9 +45,17 @@ function toggleArticlesByLinks(hide, wildcard) {
     });
 }
 
-async function fetchReactions(url) {
+async function fetchReactions(articleUrl, identifier) {
+    const params = new URLSearchParams({
+        base: 'default',
+        f: 'mezha-media',
+        't_i': identifier,
+        't_u': articleUrl,
+        's_o': 'popular'
+    });
+    const embedUrl = `https://disqus.com/embed/comments/?${params.toString()}`;
     try {
-        const res = await fetch(url);
+        const res = await fetch(embedUrl);
         const text = await res.text();
         const parser = new DOMParser();
         const doc = parser.parseFromString(text, 'text/html');
@@ -69,8 +77,10 @@ function insertReactions(article, reactions) {
 function loadReactionsForArticles() {
     document.querySelectorAll('.article').forEach(article => {
         const link = article.querySelector('.article_title a');
-        if (link) {
-            fetchReactions(link.href).then(reactions => insertReactions(article, reactions));
+        const count = article.querySelector('.disqus-comment-count');
+        if (link && count && count.dataset.disqusIdentifier) {
+            fetchReactions(link.href, count.dataset.disqusIdentifier)
+                .then(reactions => insertReactions(article, reactions));
         }
     });
 }

--- a/content.js
+++ b/content.js
@@ -55,7 +55,7 @@ function fetchReactions(articleUrl, identifier) {
     });
     const embedUrl = `https://disqus.com/embed/comments/?${params.toString()}`;
     return new Promise(resolve => {
-        chrome.runtime.sendMessage({type: 'fetchReactions', url: embedUrl}, ({html}) => {
+        chrome.runtime.sendMessage({type: 'fetchReactions', url: embedUrl, articleUrl}, ({html}) => {
             if (html) {
                 const parser = new DOMParser();
                 const doc = parser.parseFromString(html, 'text/html');
@@ -69,6 +69,11 @@ function fetchReactions(articleUrl, identifier) {
 
 function insertReactions(article, reactions) {
     if (!reactions) return;
+    const existing = article.querySelector('#reactions');
+    if (existing) {
+        existing.replaceWith(reactions.cloneNode(true));
+        return;
+    }
     const clone = reactions.cloneNode(true);
     clone.style.marginTop = '10px';
     const target = article.querySelector('.article_date') || article;

--- a/manifest.json
+++ b/manifest.json
@@ -16,10 +16,13 @@
   },
   "permissions": ["storage"],
   "host_permissions": ["https://disqus.com/*"],
-    "icons": {
-        "16": "image16.png",
-        "32": "image32.png",
-        "48": "image48.png",
-        "128": "image128.png"
+  "background": {
+    "service_worker": "background.js"
+  },
+  "icons": {
+      "16": "image16.png",
+      "32": "image32.png",
+      "48": "image48.png",
+      "128": "image128.png"
     }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -15,6 +15,7 @@
     "default_icon": "image48.png"
   },
   "permissions": ["storage"],
+  "host_permissions": ["https://disqus.com/*"],
     "icons": {
         "16": "image16.png",
         "32": "image32.png",


### PR DESCRIPTION
## Summary
- fetch reactions from every article page
- inject copied reactions into the article list

## Testing
- `node --check content.js`


------
https://chatgpt.com/codex/tasks/task_e_685431c77b80832c82948e3586c22fd8